### PR TITLE
Compatibility fixes

### DIFF
--- a/src/config.zsh
+++ b/src/config.zsh
@@ -3,7 +3,4 @@
 # Global Config Variables                                            #
 #--------------------------------------------------------------------#
 
-if [ -z "$ZSH_PRIORITIZE_CWD_HISTORY_DIR" ];then
-	# only override if there's no variable
-	ZSH_PRIORITIZE_CWD_HISTORY_DIR="$HOME/.zsh_prioritize_cwd_history"
-fi
+ZSH_PRIORITIZE_CWD_HISTORY_DIR="$HOME/.zsh_prioritize_cwd_history"

--- a/src/config.zsh
+++ b/src/config.zsh
@@ -3,4 +3,7 @@
 # Global Config Variables                                            #
 #--------------------------------------------------------------------#
 
-ZSH_PRIORITIZE_CWD_HISTORY_DIR="$HOME/.zsh_prioritize_cwd_history"
+if [ -z "$ZSH_PRIORITIZE_CWD_HISTORY_DIR" ];then
+	# only override if there's no variable
+	ZSH_PRIORITIZE_CWD_HISTORY_DIR="$HOME/.zsh_prioritize_cwd_history"
+fi

--- a/src/histrefs.zsh
+++ b/src/histrefs.zsh
@@ -53,7 +53,7 @@ _zsh_prioritize_cwd_history_load_cwd_history() {
 	# [ (valid_histrefs) ] || return
 
 	# Create a tmp file for use with `fc -R`
-	local template="$ZSH_PRIORITIZE_CWD_HISTORY_DIR/.tmphistXX"
+	local template="$ZSH_PRIORITIZE_CWD_HISTORY_DIR/.tmphistXXXX"
 	local tmp_histfile=$(mktemp "$template")
 
 	# Copy history entries executed in this directory to tmp file

--- a/src/histrefs.zsh
+++ b/src/histrefs.zsh
@@ -6,7 +6,11 @@
 # Prints to STDOUT the name of the histrefs file to use for current
 # working directory
 _zsh_prioritize_cwd_history_histrefs_for_cwd() {
-	local md5=$(echo "${PWD:A}" | md5 -q)
+	if ! type md5 > /dev/null;then
+		local md5=$(echo "${PWD:A}" | md5sum | cut -d' ' -f1)
+	else
+		local md5=$(echo "${PWD:A}" | md5 -q)
+	fi
 
 	echo "$ZSH_PRIORITIZE_CWD_HISTORY_DIR/.histrefs-$md5"
 }

--- a/zsh-prioritize-cwd-history.zsh
+++ b/zsh-prioritize-cwd-history.zsh
@@ -41,7 +41,10 @@ setopt INC_APPEND_HISTORY
 # Global Config Variables                                            #
 #--------------------------------------------------------------------#
 
-ZSH_PRIORITIZE_CWD_HISTORY_DIR="$HOME/.zsh_prioritize_cwd_history"
+if [ -z "$ZSH_PRIORITIZE_CWD_HISTORY_DIR" ];then
+	# only override if there's no variable
+	ZSH_PRIORITIZE_CWD_HISTORY_DIR="$HOME/.zsh_prioritize_cwd_history"
+fi
 
 #--------------------------------------------------------------------#
 # Histrefs files store timestamp references to entries in HISTFILE   #
@@ -50,7 +53,11 @@ ZSH_PRIORITIZE_CWD_HISTORY_DIR="$HOME/.zsh_prioritize_cwd_history"
 # Prints to STDOUT the name of the histrefs file to use for current
 # working directory
 _zsh_prioritize_cwd_history_histrefs_for_cwd() {
-	local md5=$(echo "${PWD:A}" | md5 -q)
+	if ! type md5 > /dev/null;then
+		local md5=$(echo "${PWD:A}" | md5sum | cut -d' ' -f1)
+	else
+		local md5=$(echo "${PWD:A}" | md5 -q)
+	fi
 
 	echo "$ZSH_PRIORITIZE_CWD_HISTORY_DIR/.histrefs-$md5"
 }

--- a/zsh-prioritize-cwd-history.zsh
+++ b/zsh-prioritize-cwd-history.zsh
@@ -41,10 +41,7 @@ setopt INC_APPEND_HISTORY
 # Global Config Variables                                            #
 #--------------------------------------------------------------------#
 
-if [ -z "$ZSH_PRIORITIZE_CWD_HISTORY_DIR" ];then
-	# only override if there's no variable
-	ZSH_PRIORITIZE_CWD_HISTORY_DIR="$HOME/.zsh_prioritize_cwd_history"
-fi
+ZSH_PRIORITIZE_CWD_HISTORY_DIR="$HOME/.zsh_prioritize_cwd_history"
 
 #--------------------------------------------------------------------#
 # Histrefs files store timestamp references to entries in HISTFILE   #
@@ -100,7 +97,7 @@ _zsh_prioritize_cwd_history_load_cwd_history() {
 	# [ (valid_histrefs) ] || return
 
 	# Create a tmp file for use with `fc -R`
-	local template="$ZSH_PRIORITIZE_CWD_HISTORY_DIR/.tmphistXX"
+	local template="$ZSH_PRIORITIZE_CWD_HISTORY_DIR/.tmphistXXXX"
 	local tmp_histfile=$(mktemp "$template")
 
 	# Copy history entries executed in this directory to tmp file


### PR DESCRIPTION
Notes about each commit:
- `Use md5sum if md5 if not available` is for systems that don't have the OSX md5 command
- `No clobber ZSH_PRIORITIZE_CWD_HISTORY_DIR w/source` is so that way the config variable doesn't have to be after the source
- `Update built copy with fixes` is what it says
- `Don't use too few X's` is for versions of mktemp that complain about using too few placeholder characters
